### PR TITLE
changing build script to generate code once and only compile for abis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ APIGENERATOR_CLASSES	:= $(addprefix $(BUILDDIR)/,$(APIGENERATOR_SRCS:%.java=%.cl
 static-apilib: ${GENDIR}/API.h ${GENDIR}/Makefile
 	@make -C ${GENDIR} LIBNAME=${LIBNAME} BUILDDIR=${PLATFORM_BUILDDIR} static-lib
 
+compile-static-apilib:
+	@make -C ${GENDIR} LIBNAME=${LIBNAME} BUILDDIR=${PLATFORM_BUILDDIR} static-lib
+
 api: ${GENDIR}/API.h ${GENDIR}/Makefile
 	@make -C ${GENDIR}  BUILDDIR=${PLATFORM_BUILDDIR} compile
 

--- a/build.pl
+++ b/build.pl
@@ -72,10 +72,12 @@ sub BuildAndroid
     PrepareAndroidSDK::GetAndroidSDK("$api", "21", "r10e", "24");
 
     system("make clean") && die("Clean failed");
-    system("make -j$threads PLATFORM=android ABI=armeabi-v7a APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android armv7 library");
-    system("make -j$threads PLATFORM=android ABI=x86         APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android x86 library");
-    system("make -j$threads PLATFORM=android ABI=armeabi     APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android armv5 library");
-    system("make -j$threads PLATFORM=android ABI=mips        APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android mips library");
+    system("make api-source PLATFORM=android APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make API source");
+    system("make api-module PLATFORM=android APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make API module");
+    system("make compile-static-apilib -j$threads PLATFORM=android ABI=armeabi-v7a APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android armv7 library");
+    system("make compile-static-apilib -j$threads PLATFORM=android ABI=x86         APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android x86 library");
+    system("make compile-static-apilib -j$threads PLATFORM=android ABI=armeabi     APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android armv5 library");
+    system("make compile-static-apilib -j$threads PLATFORM=android ABI=mips        APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android mips library");
 }
 
 sub ZipIt


### PR DESCRIPTION
Because the code would be regenerated every time after compiling for each ABI, it would then leave the last generated API.h file to use in the Unity. This made a strange vtable mix-up that would end up in jnibridge calling wrong functions. build now generates code once and compiles the same code to each ABI 