### PR TITLE
Fix PushLocalFrame logic

### DIFF
--- a/JNIBridge.cpp
+++ b/JNIBridge.cpp
@@ -32,7 +32,7 @@ jobject kNull(0);
 // --------------------------------------------------------------------------------------
 static jint PushLocalFrame(jint capacity)
 {
-	JNI_CALL_RETURN(jint, true, true, env->PushLocalFrame(capacity));
+	JNI_CALL_RETURN(jint, true, false, env->PushLocalFrame(capacity));
 }
 
 static jobject PopLocalFrame(jobject result)
@@ -411,7 +411,12 @@ ThreadScope::~ThreadScope()
 // --------------------------------------------------------------------------------------
 LocalFrame::LocalFrame(jint capacity)
 {
-	ClearErrors();
+	if (PeekError() != kJNI_NO_ERROR)
+	{
+		FatalError("Pushing new local frame with error present");
+		m_FramePushed = false;
+		return;
+	}
 	if (PushLocalFrame(capacity) < 0)
 		FatalError("Out of memory: Unable to allocate local frame(64)");
 	m_FramePushed = (PeekError() == kJNI_NO_ERROR);

--- a/JNIBridge.cpp
+++ b/JNIBridge.cpp
@@ -411,15 +411,9 @@ ThreadScope::~ThreadScope()
 // --------------------------------------------------------------------------------------
 LocalFrame::LocalFrame(jint capacity)
 {
-	if (PeekError() != kJNI_NO_ERROR)
-	{
-		FatalError("Pushing new local frame with error present");
-		m_FramePushed = false;
-		return;
-	}
-	if (PushLocalFrame(capacity) < 0)
+	m_FramePushed = PushLocalFrame(capacity) == 0;
+	if (!m_FramePushed)
 		FatalError("Out of memory: Unable to allocate local frame(64)");
-	m_FramePushed = (PeekError() == kJNI_NO_ERROR);
 }
 LocalFrame::~LocalFrame()
 {

--- a/JNIBridge.cpp
+++ b/JNIBridge.cpp
@@ -45,7 +45,7 @@ static jobject PopLocalFrame(jobject result)
 // --------------------------------------------------------------------------------------
 struct Error
 {
-	Errno errno;
+	Errno _errno;
 	char  errstr[256];
 };
 static TLS<Error*> g_Error;
@@ -62,13 +62,13 @@ static inline Error& GetErrorInternal()
 	return *error;
 }
 
-static inline void SetError(Errno errno, const char* errmsg)
+static inline void SetError(Errno _errno, const char* errmsg)
 {
 	Error& error = GetErrorInternal();
-	if (error.errno)
+	if (error._errno)
 		return;
 
-	error.errno = errno;
+	error._errno = _errno;
 	strcpy(error.errstr, errmsg);
 }
 
@@ -77,7 +77,7 @@ static void ClearErrors()
 	JNIEnv* env = AttachCurrentThread();
 	if (env)
 	{
-		GetErrorInternal().errno = kJNI_NO_ERROR;
+		GetErrorInternal()._errno = kJNI_NO_ERROR;
 		env->ExceptionClear();
 	}
 }
@@ -92,7 +92,7 @@ void Initialize(JavaVM& vm)
 
 Errno PeekError()
 {
-	return GetErrorInternal().errno;
+	return GetErrorInternal()._errno;
 }
 
 const char* GetErrorMessage()
@@ -102,10 +102,10 @@ const char* GetErrorMessage()
 
 Errno CheckError()
 {
-	Errno errno = PeekError();
-	if (errno)
+	Errno _errno = PeekError();
+	if (_errno)
 		ClearErrors();
-	return errno;
+	return _errno;
 }
 
 jthrowable ExceptionThrown(jclass clazz)
@@ -144,7 +144,7 @@ bool CheckForExceptionError(JNIEnv* env) // Do we need to make this safer?
 	if (env->ExceptionCheck())
 	{
 		Error& error = GetErrorInternal();
-		if (!error.errno)
+		if (!error._errno)
 		{
 			SetError(kJNI_EXCEPTION_THROWN, "java.lang.IllegalThreadStateException: Unable to determine exception message");
 

--- a/JNIBridge.cpp
+++ b/JNIBridge.cpp
@@ -411,6 +411,7 @@ ThreadScope::~ThreadScope()
 // --------------------------------------------------------------------------------------
 LocalFrame::LocalFrame(jint capacity)
 {
+	ClearErrors();
 	if (PushLocalFrame(capacity) < 0)
 		FatalError("Out of memory: Unable to allocate local frame(64)");
 	m_FramePushed = (PeekError() == kJNI_NO_ERROR);

--- a/JNIBridge.java
+++ b/JNIBridge.java
@@ -1,6 +1,7 @@
 package bitter.jnibridge;
 
 import java.lang.reflect.*;
+import java.lang.invoke.*;
 
 public class JNIBridge
 {
@@ -21,16 +22,65 @@ public class JNIBridge
 	{
 		private Object m_InvocationLock = new Object[0];
 		private long m_Ptr;
+		private Constructor<MethodHandles.Lookup> m_constructor;
 
-		public InterfaceProxy(final long ptr) { m_Ptr = ptr; }
+		@SuppressWarnings("unused")
+		public InterfaceProxy(final long ptr)
+		{
+			m_Ptr = ptr;
 
-		public Object invoke(Object proxy, Method method, Object[] args)
+			try
+			{
+				m_constructor = MethodHandles.Lookup.class.getDeclaredConstructor(Class.class, Integer.TYPE);
+				m_constructor.setAccessible(true);
+			}
+			// MethodHandles.Lookup was added in Android Oreo, we get NoClassDefFoundError on devices with older OS versions
+			catch (NoClassDefFoundError e)
+			{
+				m_constructor = null;
+			}
+			catch (NoSuchMethodException e)
+			{
+				m_constructor = null;
+			}
+		}
+
+		private Object invokeDefault(Object proxy, Throwable t, Method m, Object[] args) throws Throwable
+		{
+			if (args == null)
+			{
+				args = new Object[0];
+			}
+			Class<?> k = m.getDeclaringClass();
+			MethodHandles.Lookup lookup = m_constructor.newInstance(k, MethodHandles.Lookup.PRIVATE);
+
+			return lookup.in(k).unreflectSpecial(m, k).bindTo(proxy).invokeWithArguments(args);
+		}
+
+		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
 		{
 			synchronized (m_InvocationLock)
 			{
 				if (m_Ptr == 0)
 					return null;
-				return JNIBridge.invoke(m_Ptr, method.getDeclaringClass(), method, args);
+
+				try
+				{
+					return JNIBridge.invoke(m_Ptr, method.getDeclaringClass(), method, args);
+				}
+				catch (NoSuchMethodError e)
+				{
+					if (m_constructor == null)
+					{
+						System.err.println("JNIBridge error: Java interface default methods are only supported since Android Oreo");
+						throw e;
+					}
+					// isDefault() is only available since API 24, instead use getModifiers to check if a method has default implementation
+					if ((method.getModifiers() & Modifier.ABSTRACT) == 0)
+						return invokeDefault(proxy, e, method, args);
+					else
+						throw e;
+				}
 			}
 		}
 

--- a/JNIBridge.java
+++ b/JNIBridge.java
@@ -15,7 +15,8 @@ public class JNIBridge
 
 	static void disableInterfaceProxy(final Object proxy)
 	{
-		((InterfaceProxy) Proxy.getInvocationHandler(proxy)).disable();
+		if (proxy != null)
+			((InterfaceProxy) Proxy.getInvocationHandler(proxy)).disable();
 	}
 
 	private static class InterfaceProxy implements InvocationHandler

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 endif
 
 JAVAFLAGS	= -XX:MaxPermSize=128M
-JAVACFLAGS  = -source 1.6 -target 1.6
+JAVACFLAGS  = -source 1.8 -target 1.8
 
 CPPFLAGS	+= -g0 -O2 -Wall -Werror -Wno-long-long -std=c++11
 

--- a/Makefile.android
+++ b/Makefile.android
@@ -3,64 +3,51 @@ APINAME	= android-26
 APIJAR	= ${ANDROID_SDK_ROOT}/platforms/${APINAME}/android.jar
 GPSJAR  = ${ANDROID_SDK_ROOT}/extras/google/google_play_services/libproject/google-play-services_lib/libs/google-play-services.jar
 
+APIRAW  = 16
 API     = android-9
 SDK		= ${ANDROID_SDK_ROOT}
 NDK		= ${ANDROID_NDK_ROOT}
 UNAME  := $(shell uname)
 HOST   := $(shell echo ${UNAME} | tr '[:upper:]' '[:lower:]')-x86_64
 
-LLVM_VERSION	= 3.5
-LLVM_TOOLCHAIN := llvm-${LLVM_VERSION}
-
 GCC_VERSION     = 4.9
 
 ifeq (${ABI}, x86)
         NDK_ARCH           := arch-x86
-        GCC_BIN_PREFIX     := i686-linux-android-
+        TRIPLE             := i686-linux-android
         GCC_TOOLCHAIN      := x86-${GCC_VERSION}
-        CPPFLAGS           := ${CPPFLAGS} -target i686-none-linux-android
-        LLVM_FLAGS          = -gcc-toolchain ${GCC_TOOLCHAIN_PATH}
-else ifeq (${ABI}, mips)
-        NDK_ARCH           := arch-mips
-        GCC_BIN_PREFIX     := mipsel-linux-android-
-        GCC_TOOLCHAIN      := mipsel-linux-android-${GCC_VERSION}
-        CPPFLAGS           := ${CPPFLAGS} -target mipsel-none-linux-android
+        CPPFLAGS           := ${CPPFLAGS} -target i686-none-linux-android -march=i686
         LLVM_FLAGS          = -gcc-toolchain ${GCC_TOOLCHAIN_PATH}
 else ifeq (${ABI}, arm64-v8a)
         NDK_ARCH           := arch-arm64
-        GCC_BIN_PREFIX     := aarch64-linux-android-
+        TRIPLE             := aarch64-linux-android
         GCC_TOOLCHAIN      := aarch64-linux-android-${GCC_VERSION}
         CPPFLAGS           := --target=aarch64-none-linux-android -march=armv8-a
         LLVM_FLAGS          = --gcc-toolchain=${GCC_TOOLCHAIN_PATH}
+        APIRAW             := 21
         API                := android-21
-else
+else ifeq (${ABI}, armeabi-v7a)
         NDK_ARCH           := arch-arm
-        GCC_BIN_PREFIX     := arm-linux-androideabi-
+        TRIPLE             := arm-linux-androideabi
         GCC_TOOLCHAIN      := arm-linux-androideabi-${GCC_VERSION}
-        CPPFLAGS           := ${CPPFLAGS} -marm
+        CPPFLAGS           := ${CPPFLAGS} -target armv7-none-linux-androideabi -march=armv7-a -mfpu=neon-fp16 -mfloat-abi=softfp
         LLVM_FLAGS          = -gcc-toolchain ${GCC_TOOLCHAIN_PATH}
-
-        ifeq (${ABI}, armeabi)
-                DEFINES    := ${DEFINES} -D__ARM_ARCH_5__ -D__ARM_ARCH_5T__ -D__ARM_ARCH_5E__ -D__ARM_ARCH_5TE__
-                CPPFLAGS   := ${CPPFLAGS} -target armv5te-none-linux-androideabi -march=armv5te -mtune=xscale -mfloat-abi=soft
-        else
-                override ABI = armeabi-v7a
-                DEFINES    := ${DEFINES} -DARCH_ARMEABIV7A
-                CPPFLAGS   := ${CPPFLAGS} -target armv5te-none-linux-androideabi-v7a -march=armv7-a -mfpu=vfp -mfloat-abi=softfp
-                LDFLAGS    := -Wl,--fix-cortex-a8
-        endif
+        DEFINES            := ${DEFINES} -DARCH_ARMEABIV7A
+        LDFLAGS            := -Wl,--fix-cortex-a8
 endif
 
-DEFINES               := ${DEFINES} -DANDROID -DHAVE_INTTYPES_H
+DEFINES               := ${DEFINES} -DANDROID -D__ANDROID_API__=$(APIRAW) -DHAVE_INTTYPES_H
 override PLATFORM      = android/${ABI}
-LLVM_TOOLCAHIN_PATH    = ${NDK}/toolchains/${LLVM_TOOLCHAIN}/prebuilt/${HOST}
+LLVM_TOOLCAHIN_PATH    = ${NDK}/toolchains/llvm/prebuilt/${HOST}
 GCC_TOOLCHAIN_PATH     = ${NDK}/toolchains/${GCC_TOOLCHAIN}/prebuilt/${HOST}
 LLVM_TOOL_PREFIX       = ${LLVM_TOOLCAHIN_PATH}/bin/
-GCC_TOOL_PREFIX        = ${GCC_TOOLCHAIN_PATH}/bin/${GCC_BIN_PREFIX}
-SYSROOT                = ${NDK}/platforms/${API}/${NDK_ARCH}
-CPPFLAGS              := ${CPPFLAGS} --sysroot=${SYSROOT} -fpic -ffunction-sections -fdata-sections -fstrict-aliasing -fvisibility=hidden -MMD
+GCC_TOOL_PREFIX        = ${GCC_TOOLCHAIN_PATH}/bin/${TRIPLE}-
+CPPSYSROOT             = ${NDK}/sysroot
+ISYSTEM                = ${CPPSYSROOT}/usr/include/${TRIPLE}
+LDSYSROOT              = ${NDK}/platforms/${API}/${NDK_ARCH}
+CPPFLAGS              := ${CPPFLAGS} --sysroot=${CPPSYSROOT} -I${ISYSTEM} -fpic -ffunction-sections -fdata-sections -fstrict-aliasing -fvisibility=hidden -MMD
 CXXFLAGS              := ${CXXFLAGS} -fno-rtti -fno-exceptions
-LDFLAGS               := ${LDFLAGS} --sysroot=${SYSROOT} -Wl,--no-undefined -Wl,--gc-sections
+LDFLAGS               := ${LDFLAGS} --sysroot=${LDSYSROOT} -Wl,--no-undefined -Wl,--gc-sections
 CXX                    = ${LLVM_TOOL_PREFIX}clang++ ${DEFINES} ${LLVM_FLAGS}
 CC                     = ${LLVM_TOOL_PREFIX}clang ${DEFINES} ${LLVM_FLAGS}
 STRIP                  = ${LLVM_TOOL_PREFIX}strip ${STRIPFLAGS}

--- a/Makefile.android
+++ b/Makefile.android
@@ -51,7 +51,7 @@ else
         endif
 endif
 
-DEFINES               := ${DEFINES} -DANDROID
+DEFINES               := ${DEFINES} -DANDROID -DHAVE_INTTYPES_H
 override PLATFORM      = android/${ABI}
 LLVM_TOOLCAHIN_PATH    = ${NDK}/toolchains/${LLVM_TOOLCHAIN}/prebuilt/${HOST}
 GCC_TOOLCHAIN_PATH     = ${NDK}/toolchains/${GCC_TOOLCHAIN}/prebuilt/${HOST}

--- a/Makefile.android
+++ b/Makefile.android
@@ -1,5 +1,5 @@
 
-APINAME	= android-23
+APINAME	= android-26
 APIJAR	= ${ANDROID_SDK_ROOT}/platforms/${APINAME}/android.jar
 GPSJAR  = ${ANDROID_SDK_ROOT}/extras/google/google_play_services/libproject/google-play-services_lib/libs/google-play-services.jar
 

--- a/Makefile.android
+++ b/Makefile.android
@@ -1,7 +1,7 @@
 
 APINAME	= android-26
 APIJAR	= ${ANDROID_SDK_ROOT}/platforms/${APINAME}/android.jar
-GPSJAR  = ${ANDROID_SDK_ROOT}/extras/google/google_play_services/libproject/google-play-services_lib/libs/google-play-services.jar
+GPSJAR  = ${ANDROID_SDK_ROOT}/extras/google/google_play_services_froyo/libproject/google-play-services_lib/libs/google-play-services.jar
 
 APIRAW  = 16
 API     = android-9

--- a/Makefile.android
+++ b/Makefile.android
@@ -12,7 +12,7 @@ HOST   := $(shell echo ${UNAME} | tr '[:upper:]' '[:lower:]')-x86_64
 LLVM_VERSION	= 3.5
 LLVM_TOOLCHAIN := llvm-${LLVM_VERSION}
 
-GCC_VERSION     = 4.8
+GCC_VERSION     = 4.9
 
 ifeq (${ABI}, x86)
         NDK_ARCH           := arch-x86
@@ -26,6 +26,13 @@ else ifeq (${ABI}, mips)
         GCC_TOOLCHAIN      := mipsel-linux-android-${GCC_VERSION}
         CPPFLAGS           := ${CPPFLAGS} -target mipsel-none-linux-android
         LLVM_FLAGS          = -gcc-toolchain ${GCC_TOOLCHAIN_PATH}
+else ifeq (${ABI}, arm64-v8a)
+        NDK_ARCH           := arch-arm64
+        GCC_BIN_PREFIX     := aarch64-linux-android-
+        GCC_TOOLCHAIN      := aarch64-linux-android-${GCC_VERSION}
+        CPPFLAGS           := --target=aarch64-none-linux-android -march=armv8-a
+        LLVM_FLAGS          = --gcc-toolchain=${GCC_TOOLCHAIN_PATH}
+        API                := android-21
 else
         NDK_ARCH           := arch-arm
         GCC_BIN_PREFIX     := arm-linux-androideabi-

--- a/PrepareAndroidSDK.pm
+++ b/PrepareAndroidSDK.pm
@@ -39,6 +39,7 @@ our $sdks =
 	"android-19"	=> "android-19_r03.zip",
 	"android-21"	=> "android-21_r02.zip",
 	"android-23"	=> "android-23_r02.zip",
+	"android-26"	=> "platform-26_r02.zip",
 };
 
 our $sdk_tools =

--- a/PrepareAndroidSDK.pm
+++ b/PrepareAndroidSDK.pm
@@ -4,15 +4,21 @@ package PrepareAndroidSDK;
 
 use strict;
 use warnings;
+
+use File::Basename;
+use File::Spec;
+use lib File::Spec->rel2abs(dirname(__FILE__)) . '/perl_lib';
+
+use Getopt::Long;
 use Carp qw(croak carp);
 use File::Path qw(mkpath rmtree);
 use File::Spec::Functions;
 use File::Copy;
-use File::Basename;
+use File::Copy::Recursive;
 
 require Exporter;
-our @ISA = qw(Exporter);
-our @EXPORT_OK=qw(GetAndroidSDK);
+our @ISA       = qw(Exporter);
+our @EXPORT_OK = qw(GetAndroidSDK);
 
 our $SDK_ROOT_ENV = "ANDROID_SDK_ROOT";
 our $NDK_ROOT_ENV = "ANDROID_NDK_ROOT";
@@ -23,521 +29,565 @@ our $BASE_URL_SDK = "http://dl.google.com/android/repository/";
 our $BASE_URL_NDK = "http://dl.google.com/android/ndk/";
 
 our $sdks =
-{
-	"android-7"		=> "android-2.1_r03-linux.zip",
-	"android-8"		=> "android-2.2_r03-linux.zip",
-	"android-9"		=> "android-2.3.1_r02-linux.zip",
-	"android-10"	=> "android-2.3.3_r02-linux.zip",
-	"android-11"	=> "android-3.0_r02-linux.zip",
-	"android-12"	=> "android-3.1_r03-linux.zip",
-	"android-13"	=> "android-3.2_r01-linux.zip",
-	"android-14"	=> "android-14_r03.zip",
-	"android-15"	=> "android-15_r03.zip",
-	"android-16"	=> "android-16_r02.zip",
-	"android-17"	=> "android-17_r01.zip",
-	"android-18"	=> "android-18_r02.zip",
-	"android-19"	=> "android-19_r03.zip",
-	"android-21"	=> "android-21_r02.zip",
-	"android-23"	=> "android-23_r02.zip",
-	"android-26"	=> "platform-26_r02.zip",
-};
+    {
+    "android-7"  => "android-2.1_r03-linux.zip",
+    "android-8"  => "android-2.2_r03-linux.zip",
+    "android-9"  => "android-2.3.1_r02-linux.zip",
+    "android-10" => "android-2.3.3_r02-linux.zip",
+    "android-11" => "android-3.0_r02-linux.zip",
+    "android-12" => "android-3.1_r03-linux.zip",
+    "android-13" => "android-3.2_r01-linux.zip",
+    "android-14" => "android-14_r03.zip",
+    "android-15" => "android-15_r03.zip",
+    "android-16" => "android-16_r02.zip",
+    "android-17" => "android-17_r01.zip",
+    "android-18" => "android-18_r02.zip",
+    "android-19" => "android-19_r03.zip",
+    "android-21" => "android-21_r02.zip",
+    "android-23" => "android-23_r02.zip",
+    };
 
 our $sdk_tools =
-{
-	"version"		=> "24.4.1",
-	"windows"		=> "tools_r24.4.1-windows.zip",
-	"linux"			=> "tools_r24.4.1-linux.zip",
-	"macosx"		=> "tools_r24.4.1-macosx.zip",
-};
+    {
+    "version" => "24.4.1",
+    "windows" => "tools_r24.4.1-windows.zip",
+    "linux"   => "tools_r24.4.1-linux.zip",
+    "macosx"  => "tools_r24.4.1-macosx.zip",
+    };
 
 our $platform_tools =
-{
-	"version"		=> "23.1.0",
-	"windows"		=> "platform-tools_r23.1.0-windows.zip",
-	"linux"			=> "platform-tools_r23.1.0-linux.zip",
-	"macosx"		=> "platform-tools_r23.1.0-macosx.zip",
-};
+    {
+    "version" => "23.1.0",
+    "windows" => "platform-tools_r23.1.0-windows.zip",
+    "linux"   => "platform-tools_r23.1.0-linux.zip",
+    "macosx"  => "platform-tools_r23.1.0-macosx.zip",
+    };
 
 our $build_tools =
-{
-	"version"		=> "23.0.2",
-	"windows"		=> "build-tools_r23.0.2-windows.zip",
-	"linux"			=> "build-tools_r23.0.2-linux.zip",
-	"macosx"		=> "build-tools_r23.0.2-macosx.zip",
-};
+    {
+    "version" => "25.0.2",
+    "windows" => "build-tools_r25.0.2-windows.zip",
+    "linux"   => "build-tools_r25.0.2-linux.zip",
+    "macosx"  => "build-tools_r25.0.2-macosx.zip",
+    };
 
 our $ndks =
-{
-	"r5"		=>
-					{
-						"windows" => "android-ndk-r5-windows.zip",
-						"macosx" => "android-ndk-r5-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r5-linux-x86.tar.bz2",
-					},
-	"r5b"		=>
-					{
-						"windows" => "android-ndk-r5b-windows.zip",
-						"macosx" => "android-ndk-r5b-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r5b-linux-x86.tar.bz2",
-					},
-	"r5c"		=>
-					{
-						"windows" => "android-ndk-r5c-windows.zip",
-						"macosx" => "android-ndk-r5c-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r5c-linux-x86.tar.bz2",
-					},
-	"r6"		=>
-					{
-						"windows" => "android-ndk-r6-windows.zip",
-						"macosx" => "android-ndk-r6-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r6-linux-x86.tar.bz2",
-					},
-	"r6b"		=>
-					{
-						"windows" => "android-ndk-r6b-windows.zip",
-						"macosx" => "android-ndk-r6b-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r6b-linux-x86.tar.bz2",
-					},
-	"r7"		=>
-					{
-						"windows" => "android-ndk-r7-windows.zip",
-						"macosx" => "android-ndk-r7-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r7-linux-x86.tar.bz2",
-					},
-	"r7b"		=>
-					{
-						"windows" => "android-ndk-r7b-windows.zip",
-						"macosx" => "android-ndk-r7b-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r7b-linux-x86.tar.bz2",
-					},
-	"r7c"		=>
-					{
-						"windows" => "android-ndk-r7c-windows.zip",
-						"macosx" => "android-ndk-r7c-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r7c-linux-x86.tar.bz2",
-					},
-	"r8"		=>
-					{
-						"windows" => "android-ndk-r8-windows.zip",
-						"macosx" => "android-ndk-r8-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r8-linux-x86.tar.bz2",
-					},
-	"r8b"		=>
-					{
-						"windows" => "android-ndk-r8b-windows.zip",
-						"macosx" => "android-ndk-r8b-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r8b-linux-x86.tar.bz2",
-					},
-	"r8c"		=>
-					{
-						"windows" => "android-ndk-r8c-windows.zip",
-						"macosx" => "android-ndk-r8c-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r8c-linux-x86.tar.bz2",
-					},
-	"r8e"		=>
-					{
-						"windows" => "android-ndk-r8e-windows.zip",
-						"macosx" => "android-ndk-r8e-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r8e-linux-x86.tar.bz2",
-					},
-	"r9"		=>
-					{
-						"windows" => "android-ndk-r9-windows-x86.zip",
-						"macosx" => "android-ndk-r9-darwin-x86.tar.bz2",
-						"linux" => "android-ndk-r9-linux-x86.tar.bz2",
-					},
-	"r10b"		=>
-					{
-						"windows" => "android-ndk32-r10b-windows-x86.zip",
-						"macosx" => "android-ndk32-r10b-darwin-x86.tar.bz2",
-						"linux" => "android-ndk32-r10b-linux-x86.tar.bz2",
-					},
-	"r10e"		=>
-					{
-						"windows" => "android-ndk-r10e-windows-x86.exe",
-						"macosx" => "android-ndk-r10e-darwin-x86_64.bin",
-						"linux" => "android-ndk-r10e-linux-x86.bin",
-					},
-};
+    {
+    "r5" =>
+        {
+        "windows" => "android-ndk-r5-windows.zip",
+        "macosx"  => "android-ndk-r5-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r5-linux-x86.tar.bz2",
+        },
+    "r5b" =>
+        {
+        "windows" => "android-ndk-r5b-windows.zip",
+        "macosx"  => "android-ndk-r5b-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r5b-linux-x86.tar.bz2",
+        },
+    "r5c" =>
+        {
+        "windows" => "android-ndk-r5c-windows.zip",
+        "macosx"  => "android-ndk-r5c-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r5c-linux-x86.tar.bz2",
+        },
+    "r6" =>
+        {
+        "windows" => "android-ndk-r6-windows.zip",
+        "macosx"  => "android-ndk-r6-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r6-linux-x86.tar.bz2",
+        },
+    "r6b" =>
+        {
+        "windows" => "android-ndk-r6b-windows.zip",
+        "macosx"  => "android-ndk-r6b-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r6b-linux-x86.tar.bz2",
+        },
+    "r7" =>
+        {
+        "windows" => "android-ndk-r7-windows.zip",
+        "macosx"  => "android-ndk-r7-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r7-linux-x86.tar.bz2",
+        },
+    "r7b" =>
+        {
+        "windows" => "android-ndk-r7b-windows.zip",
+        "macosx"  => "android-ndk-r7b-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r7b-linux-x86.tar.bz2",
+        },
+    "r7c" =>
+        {
+        "windows" => "android-ndk-r7c-windows.zip",
+        "macosx"  => "android-ndk-r7c-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r7c-linux-x86.tar.bz2",
+        },
+    "r8" =>
+        {
+        "windows" => "android-ndk-r8-windows.zip",
+        "macosx"  => "android-ndk-r8-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r8-linux-x86.tar.bz2",
+        },
+    "r8b" =>
+        {
+        "windows" => "android-ndk-r8b-windows.zip",
+        "macosx"  => "android-ndk-r8b-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r8b-linux-x86.tar.bz2",
+        },
+    "r8c" =>
+        {
+        "windows" => "android-ndk-r8c-windows.zip",
+        "macosx"  => "android-ndk-r8c-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r8c-linux-x86.tar.bz2",
+        },
+    "r8e" =>
+        {
+        "windows" => "android-ndk-r8e-windows.zip",
+        "macosx"  => "android-ndk-r8e-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r8e-linux-x86.tar.bz2",
+        },
+    "r9" =>
+        {
+        "windows" => "android-ndk-r9-windows-x86.zip",
+        "macosx"  => "android-ndk-r9-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk-r9-linux-x86.tar.bz2",
+        },
+    "r10b" =>
+        {
+        "windows" => "android-ndk32-r10b-windows-x86.zip",
+        "macosx"  => "android-ndk32-r10b-darwin-x86.tar.bz2",
+        "linux"   => "android-ndk32-r10b-linux-x86.tar.bz2",
+        },
+    "r10e" =>
+        {
+        "windows" => "android-ndk-r10e-windows-x86_64.exe",
+        "macosx"  => "android-ndk-r10e-darwin-x86_64.bin",
+        "linux"   => "android-ndk-r10e-linux-x86_64.bin",
+        },
+    "r13b" =>
+        {
+        "windows" => "android-ndk-r13b-windows-x86_64.zip",
+        "macosx"  => "android-ndk-r13b-darwin-x86_64.zip",
+        "linux"   => "android-ndk-r13b-linux-x86_64.zip",
+        },
+    "r17" =>
+        {
+        "windows" => "android-ndk-r17-windows-x86_64.zip",
+        "macosx"  => "android-ndk-r17-darwin-x86_64.zip",
+        "linux"   => "android-ndk-r17-linux-x86_64.zip",
+        },
+    };
 
-our $google_play_services =
-{
-	"24" => "google_play_services_7327000_r24.zip"
-};
+our $sourcePropVersions =
+    {
+    "13.1.3345770" => "r13b (64-bit)",
+    "17.0.4754217" => "r17 (64-bit)",
+    };
 
 our ($HOST_ENV, $TMP, $HOME, $WINZIP);
 
 sub GetAndroidSDK
 {
-if(lc $^O eq 'darwin')
-{
-		$HOST_ENV = "macosx";
-		$TMP = $ENV{"TMPDIR"};
-		$HOME = $ENV{"HOME"};
-}
-elsif(lc $^O eq 'linux')
-{
-	$HOST_ENV = "linux";
-	$TMP = "/tmp";
-	$HOME = $ENV{"HOME"};
-}
-elsif(lc $^O eq 'mswin32')
-{
-	$HOST_ENV = "windows";
-	$TMP = $ENV{"TMP"};
-	$HOME = $ENV{"USERPROFILE"};
-	if (-e "Tools/WinUtils/7z/7z.exe")
-	{
-		$WINZIP = "Tools/WinUtils/7z/7z.exe";
-	}
-}
-elsif(lc $^O eq 'cygwin')
-{
-	$HOST_ENV = "windows";
-	$TMP = $ENV{"TMP"};
-	$HOME = $ENV{"HOME"};
-}
-else
-{
-	die "UNKNOWN " . $^O;
-}
+    if (lc $^O eq 'darwin')
+    {
+        $HOST_ENV = "macosx";
+        $TMP      = $ENV{"TMPDIR"};
+        $HOME     = $ENV{"HOME"};
+    }
+    elsif (lc $^O eq 'linux')
+    {
+        $HOST_ENV = "linux";
+        $TMP      = "/tmp";
+        $HOME     = $ENV{"HOME"};
+    }
+    elsif (lc $^O eq 'mswin32')
+    {
+        $HOST_ENV = "windows";
+        $TMP      = $ENV{"TMP"};
+        $HOME     = $ENV{"USERPROFILE"};
+        if (-e "External/7z/win32/7za.exe")
+        {
+            $WINZIP = "External/7z/win32/7za.exe";
+        }
+    }
+    elsif (lc $^O eq 'cygwin')
+    {
+        $HOST_ENV = "windows";
+        $TMP      = $ENV{"TMP"};
+        $HOME     = $ENV{"HOME"};
+    }
+    else
+    {
+        die "UNKNOWN " . $^O;
+    }
 
-	print "Environment:\n";
-	print "\tHost      = $HOST_ENV\n";
-	print "\tTemporary = $TMP\n";
-	print "\tHome      = $HOME\n";
-	print "\n";
-	print "\t\$$SDK_ROOT_ENV = $ENV{$SDK_ROOT_ENV}\n" if ($ENV{$SDK_ROOT_ENV});
-	print "\t\$$NDK_ROOT_ENV = $ENV{$NDK_ROOT_ENV}\n" if ($ENV{$NDK_ROOT_ENV});
-	print "\n";
+    print "Environment:\n";
+    print "\tHost      = $HOST_ENV\n";
+    print "\tTemporary = $TMP\n";
+    print "\tHome      = $HOME\n";
+    print "\n";
+    print "\t\$$SDK_ROOT_ENV = $ENV{$SDK_ROOT_ENV}\n" if ($ENV{$SDK_ROOT_ENV});
+    print "\t\$$NDK_ROOT_ENV = $ENV{$NDK_ROOT_ENV}\n" if ($ENV{$NDK_ROOT_ENV});
+    print "\n";
 
-my ($sdk, $tools, $ndk, $gps, $setenv) = @_;
+    my ($sdk, $tools, $ndk, $setenv) = @_;
 
-#	Getopt::Long::GetOptions("sdk=s"=>\$sdk, "ndk=s"=>\$ndk) or die ("Illegal cmdline options");
+#   Getopt::Long::GetOptions("sdk=s"=>\$sdk, "ndk=s"=>\$ndk) or die ("Illegal cmdline options");
 
-if ($sdk or $tools)
-{
-	if ($sdk)
-	{
-		print "Installing SDK '$sdk':\n";
-	}
-	elsif($tools)
-	{
-		print "Installing SDK Tools '$tools':\n";
-	}
+    if ($sdk or $tools)
+    {
+        if ($sdk)
+        {
+            print "Installing SDK '$sdk':\n";
+        }
+        elsif ($tools)
+        {
+            print "Installing SDK Tools '$tools':\n";
+        }
 
-	if (!$ENV{$SDK_ROOT_ENV})
-	{
-		$ENV{$SDK_ROOT_ENV} = catfile($HOME, "android-sdk_auto");
-		print "\t\$$SDK_ROOT_ENV not set; using $ENV{$SDK_ROOT_ENV} instead\n";
-	}
+        if (!$ENV{$SDK_ROOT_ENV})
+        {
+            $ENV{$SDK_ROOT_ENV} = catfile($HOME, "android-sdk_auto");
+            print "\t\$$SDK_ROOT_ENV not set; using $ENV{$SDK_ROOT_ENV} instead\n";
+        }
 
-	if (not $tools and $sdk)
-	{
-		my @split = split('-', $sdk);
-		$tools = $split[1];
-	}
-	if ($tools)
-	{
-		PrepareSDKTools($tools);
-	}
-	if ($sdk)
-	{
-		PrepareSDK($sdk);
-	}
-	if ($gps)
-	{
-		print "Installing Google Play Services '$gps':\n";
-		PrepareGPS($gps);
-		print "\n";
-	}
-	print "\n";
-}
+        if (not $tools and $sdk)
+        {
+            my @split = split('-', $sdk);
+            $tools = $split[1];
+        }
+        if ($tools)
+        {
+            PrepareSDKTools($tools);
+        }
+        if ($sdk)
+        {
+            PrepareSDK($sdk);
+        }
+        print "\n";
+    }
 
-if ($ndk)
-{
-	print "Installing NDK '$ndk':\n";
-	if (!$ENV{$NDK_ROOT_ENV})
-	{
-		$ENV{$NDK_ROOT_ENV} = catfile($HOME, "android-ndk_auto-" . $ndk);
-		print "\t\$$NDK_ROOT_ENV not set; using $ENV{$NDK_ROOT_ENV} instead\n";
-	}
-	PrepareNDK($ndk);
-	print "\n";
-}
+    if ($ndk)
+    {
+        print "Installing NDK '$ndk':\n";
+        if (!$ENV{$NDK_ROOT_ENV})
+        {
+            $ENV{$NDK_ROOT_ENV} = catfile($HOME, "android-ndk_auto-" . $ndk);
+            print "\t\$$NDK_ROOT_ENV not set; using $ENV{$NDK_ROOT_ENV} instead\n";
+        }
+        PrepareNDK($ndk);
+        print "\n";
+    }
 
-	my $export = "export";
-	if (lc $^O eq 'mswin32')
-	{
-		$export = "set";
-	}
+    my $export = "export";
+    if (lc $^O eq 'mswin32')
+    {
+        $export = "set";
+    }
 
-	if ($setenv and ($ENV{$SDK_ROOT_ENV} or $ENV{$SDK_ROOT_ENV}))
-	{
-		print "Outputing updated environment:\n";
-		print "\t'$setenv'\n";
-		open (SETENV, '>' . $setenv);
-		print SETENV "$export $SDK_ROOT_ENV=$ENV{$SDK_ROOT_ENV}\n" if ($ENV{$SDK_ROOT_ENV});
-		print SETENV "$export $NDK_ROOT_ENV=$ENV{$NDK_ROOT_ENV}\n" if ($ENV{$NDK_ROOT_ENV});
-		close (SETENV);
-		print "\n";
-	}
+    if ($setenv and ($ENV{$SDK_ROOT_ENV} or $ENV{$SDK_ROOT_ENV}))
+    {
+        print "Outputing updated environment:\n";
+        print "\t'$setenv'\n";
+        open(SETENV, '>' . $setenv);
+        print SETENV "$export $SDK_ROOT_ENV=$ENV{$SDK_ROOT_ENV}\n" if ($ENV{$SDK_ROOT_ENV});
+        print SETENV "$export $NDK_ROOT_ENV=$ENV{$NDK_ROOT_ENV}\n" if ($ENV{$NDK_ROOT_ENV});
+        close(SETENV);
+        print "\n";
+    }
 
-	print "Environment:\n" if ($ENV{$SDK_ROOT_ENV} or $ENV{$SDK_ROOT_ENV});
-	print "\t\$$SDK_ROOT_ENV = $ENV{$SDK_ROOT_ENV}\n" if ($ENV{$SDK_ROOT_ENV});
-	print "\t\$$NDK_ROOT_ENV = $ENV{$NDK_ROOT_ENV}\n" if ($ENV{$NDK_ROOT_ENV});
-	print "\n";
+    print "Environment:\n" if ($ENV{$SDK_ROOT_ENV} or $ENV{$SDK_ROOT_ENV});
+    print "\t\$$SDK_ROOT_ENV = $ENV{$SDK_ROOT_ENV}\n" if ($ENV{$SDK_ROOT_ENV});
+    print "\t\$$NDK_ROOT_ENV = $ENV{$NDK_ROOT_ENV}\n" if ($ENV{$NDK_ROOT_ENV});
+    print "\n";
 }
 
 sub PrepareSDKTools
 {
-	my $sdk_root = $ENV{$SDK_ROOT_ENV};
-	my $sdk_tool_path = catfile($sdk_root, "tools");
-	my $sdk_platform_tool_path = catfile($sdk_root, "platform-tools");
-	my $sdk_build_tool_path = catfile($sdk_root, "build-tools", $build_tools->{'version'});
+    my $sdk_root               = $ENV{$SDK_ROOT_ENV};
+    my $sdk_tool_path          = catfile($sdk_root, "tools");
+    my $sdk_platform_tool_path = catfile($sdk_root, "platform-tools");
+    my $sdk_build_tool_path    = catfile($sdk_root, "build-tools", $build_tools->{'version'});
 
-	my $sdk_tool_version = GetToolsRevisionMajor("$sdk_tool_path");
-	my $sdk_platform_tool_version = GetToolsRevisionMajor("$sdk_platform_tool_path");
-	my $sdk_build_tool_version = GetToolsRevisionMajor("$sdk_build_tool_path");
+    my $sdk_tool_version          = GetToolsRevisionMajor("$sdk_tool_path");
+    my $sdk_platform_tool_version = GetToolsRevisionMajor("$sdk_platform_tool_path");
+    my $sdk_build_tool_version    = GetToolsRevisionMajor("$sdk_build_tool_path");
 
-	my $sdk_tool = $sdk_tools->{$HOST_ENV};
-	my $platform_tool = $platform_tools->{$HOST_ENV};
-	my $build_tool = $build_tools->{$HOST_ENV};
-	die ("Unknown host environment '$HOST_ENV'") if (!$sdk_tool or !$platform_tool or !$build_tool);
+    my $sdk_tool      = $sdk_tools->{$HOST_ENV};
+    my $platform_tool = $platform_tools->{$HOST_ENV};
+    my $build_tool    = $build_tools->{$HOST_ENV};
+    die("Unknown host environment '$HOST_ENV'") if (!$sdk_tool or !$platform_tool or !$build_tool);
 
-	if (ParseMajor($sdk_tools->{'version'}) != $sdk_tool_version)
-	{
-		print "\tInstalling Tools\n";
-		DownloadAndUnpackArchive($BASE_URL_SDK . $sdk_tool, "$sdk_tool_path");
-	}
+    if (ParseMajor($sdk_tools->{'version'}) != $sdk_tool_version)
+    {
+        print "\tInstalling Tools\n";
+        DownloadAndUnpackArchive($BASE_URL_SDK . $sdk_tool, "$sdk_tool_path");
+    }
 
-	if (ParseMajor($platform_tools->{'version'}) != $sdk_platform_tool_version)
-	{
-		print "\tInstalling Platform Tools\n";
-		DownloadAndUnpackArchive($BASE_URL_SDK . $platform_tool, "$sdk_platform_tool_path");
-	}
+    if (ParseMajor($platform_tools->{'version'}) != $sdk_platform_tool_version)
+    {
+        print "\tInstalling Platform Tools\n";
+        DownloadAndUnpackArchive($BASE_URL_SDK . $platform_tool, "$sdk_platform_tool_path");
+    }
 
-	if (ParseMajor($build_tools->{'version'}) != $sdk_build_tool_version)
-	{
-		print "\tInstalling Build Tools\n";
-		DownloadAndUnpackArchive($BASE_URL_SDK . $build_tool, "$sdk_build_tool_path");
-	}
+    if (ParseMajor($build_tools->{'version'}) != $sdk_build_tool_version)
+    {
+        print "\tInstalling Build Tools\n";
+        DownloadAndUnpackArchive($BASE_URL_SDK . $build_tool, "$sdk_build_tool_path");
+    }
 }
 
 sub ParseMajor
 {
-	my ($version_str) = @_;
-	my @version_numbers = split('\.', $version_str);
-	return int($version_numbers[0]);
+    my ($version_str) = @_;
+    my @version_numbers = split('\.', $version_str);
+    return int($version_numbers[0]);
 }
 
 sub GetToolsRevisionMajor
 {
-	my ($tools_dir) = @_;
-	if (open PROPS, "<", catfile("$tools_dir", "source.properties"))
-	{
-		my @content = <PROPS>;
-		close PROPS;
-		chomp(@content);
-		foreach (@content)
-		{
-			if (index($_, "Pkg.Revision") != -1)
-			{
-				my @tokens = split('=', $_);
-				return ParseMajor($tokens[1]);
-			}
-		}
-	}
-	return 0;
+    my ($tools_dir) = @_;
+    if (open PROPS, "<", catfile("$tools_dir", "source.properties"))
+    {
+        my @content = <PROPS>;
+        close PROPS;
+        chomp(@content);
+        foreach (@content)
+        {
+            if (index($_, "Pkg.Revision") != -1)
+            {
+                my @tokens = split('=', $_);
+                return ParseMajor($tokens[1]);
+            }
+        }
+    }
+    return 0;
 }
 
 sub PrepareSDK
 {
-	my $sdk_root = $ENV{$SDK_ROOT_ENV};
+    my $sdk_root = $ENV{$SDK_ROOT_ENV};
 
-	my ($sdk) = @_;
+    my ($sdk) = @_;
 
-	if (IsPlatformInstalled($sdk))
-	{
-		print "\tPlatform '$sdk' is already installed\n";
-		return;
-	}
+    if (IsPlatformInstalled($sdk))
+    {
+        print "\tPlatform '$sdk' is already installed\n";
+        return;
+    }
 
-	my $platform = $sdks->{$sdk};
-	die ("Unknown platform API '$sdk'") if (!$platform);
+    my $platform = $sdks->{$sdk};
+    die("Unknown platform API '$sdk'") if (!$platform);
 
-	my $output = catfile($sdk_root, "platforms", $sdk);
-	print "\tDownloading '$platform' to '$output'\n";
-	DownloadAndUnpackArchive($BASE_URL_SDK . $platform, $output);
-}
-
-sub PrepareGPS
-{
-	my $sdk_root = $ENV{$SDK_ROOT_ENV};
-
-	my ($gps_version) = @_;
-
-	my $gps = $google_play_services->{$gps_version};
-	die ("Unknown Google Play Services version '$gps_version'") if (!$gps);
-
-	my $output = catfile($sdk_root, "extras", "google", "google_play_services");
-	my $gps_jar = catfile($output, "libproject", "google-play-services_lib", "libs", "google-play-services.jar");
-	if (-e $gps_jar)
-	{
-		print "\tGoogle Play Services version '$gps_version' is already installed\n";
-		return;
-	}
-
-	print "\tDownloading '$gps' to '$output'\n";
-	DownloadAndUnpackArchive($BASE_URL_SDK . $gps, $output);
+    my $output = catfile($sdk_root, "platforms", $sdk);
+    print "\tDownloading '$platform' to '$output'\n";
+    DownloadAndUnpackArchive($BASE_URL_SDK . $platform, $output);
 }
 
 sub IsPlatformInstalled
 {
-	my $sdk_root = $ENV{$SDK_ROOT_ENV};
-	my ($sdk) = @_;
-	if (! $sdk_root)
-	{
-		return 0;
-	}
-	unless (grep {$_ eq $sdk} GetCurrentSDKPlatforms($sdk_root))
-	{
-		return 0;
-	}
-	return 1;
+    my $sdk_root = $ENV{$SDK_ROOT_ENV};
+    my ($sdk) = @_;
+    if (!$sdk_root)
+    {
+        return 0;
+    }
+    unless (grep { $_ eq $sdk } GetCurrentSDKPlatforms($sdk_root))
+    {
+        return 0;
+    }
+    return 1;
 }
 
 sub GetCurrentSDKPlatforms
 {
-	my ($sdk_root) = @_;
-	my $platform_root = $sdk_root . "/platforms";
-	opendir(my $dh, $platform_root) || return;
-	my @platforms = grep { !/^\.\.?$/ && -e catfile($platform_root, $_, "android.jar") } readdir($dh);
-	closedir $dh;
+    my ($sdk_root) = @_;
+    my $platform_root = $sdk_root . "/platforms";
+    opendir(my $dh, $platform_root) || return;
+    my @platforms = grep { !/^\.\.?$/ && -e catfile($platform_root, $_, "android.jar") } readdir($dh);
+    closedir $dh;
 
-	return @platforms;
+    return @platforms;
 }
 
 sub DownloadAndUnpackArchive
 {
-	my ($url, $output) = @_;
-	my ($base,$base_url,$suffix) = fileparse($url, qr/\.[^.]*/);
-	my ($dest_name,$dest_path) = fileparse($output);
+    my ($url, $output) = @_;
+    my ($base, $base_url, $suffix) = fileparse($url, qr/\.[^.]*/);
+    my ($dest_name, $dest_path) = fileparse($output);
 
-	my $temporary_download_path = catfile($TMP, $base . $suffix);
-	my $temporary_unpack_path = catfile($TMP, $base . "_unpack");
+    my $temporary_download_path = catfile($TMP, $base . $suffix);
+    my $temporary_unpack_path   = catfile($TMP, $base . "_unpack");
 
-	print "\t\tURL: " . $url . "\n";
-	print "\t\tOutput: " . $output . "\n";
-	print "\t\tBase: " . $base . "\n";
-	print "\t\tURL base: " . $base_url . "\n";
-	print "\t\tSuffix: " . $suffix . "\n";
-	print "\t\tTmp DL: " . $temporary_download_path . "\n";
-	print "\t\tTmp unpack: " . $temporary_unpack_path . "\n";
-	print "\t\tDest path: " . $dest_path . "\n";
-	print "\t\tDest name: " . $dest_name . "\n";
+    print "\t\tURL: " . $url . "\n";
+    print "\t\tOutput: " . $output . "\n";
+    print "\t\tBase: " . $base . "\n";
+    print "\t\tURL base: " . $base_url . "\n";
+    print "\t\tSuffix: " . $suffix . "\n";
+    print "\t\tTmp DL: " . $temporary_download_path . "\n";
+    print "\t\tTmp unpack: " . $temporary_unpack_path . "\n";
+    print "\t\tDest path: " . $dest_path . "\n";
+    print "\t\tDest name: " . $dest_name . "\n";
 
-	# remove old output
-	rmtree($output);
-	mkpath($dest_path);
+    # remove old output
+    rmtree($output);
+    mkpath($dest_path);
 
-	# create temporary locations
-	unlink($temporary_download_path);
-	rmtree($temporary_unpack_path);
-	mkpath($temporary_unpack_path);
+    # create temporary locations
+    unlink($temporary_download_path);
+    rmtree($temporary_unpack_path);
+    mkpath($temporary_unpack_path);
 
-	system("lwp-download", $url, $temporary_download_path);
+    system("lwp-download", $url, $temporary_download_path);
 
-	if ($WINZIP)
-	{
-		system($WINZIP, "x", $temporary_download_path, "-o" . $temporary_unpack_path);
-	}
-	else
-	{
-		if (lc $suffix eq '.zip')
-		{
-			system("unzip", "-q", $temporary_download_path, "-d", $temporary_unpack_path);
-		}
-		elsif (lc $suffix eq '.bz2')
-		{
-			system("tar", "-xf", $temporary_download_path, "-C", $temporary_unpack_path);
-		}
-		elsif (lc $suffix eq '.bin')
-		{	chmod(0755, $temporary_download_path);
-			system($temporary_download_path, "-o" . $temporary_unpack_path);
-		}
-		elsif (lc $suffix eq '.exe')
-		{	chmod(0755, $temporary_download_path);
-			system($temporary_download_path, "-o" . $temporary_unpack_path);
-		}
-		else
-		{
-			die "Unknown file extension '" . $suffix . "'\n";
-		}
-	}
+    if ($WINZIP)
+    {
+        system($WINZIP, "x", $temporary_download_path, "-o" . $temporary_unpack_path);
+    }
+    else
+    {
+        if (lc $suffix eq '.zip')
+        {
+            system("unzip", "-q", $temporary_download_path, "-d", $temporary_unpack_path);
+        }
+        elsif (lc $suffix eq '.bz2')
+        {
+            system("tar", "-xf", $temporary_download_path, "-C", $temporary_unpack_path);
+        }
+        elsif (lc $suffix eq '.bin')
+        { chmod(0755, $temporary_download_path);
+            system($temporary_download_path, "-o" . $temporary_unpack_path);
+        }
+        elsif (lc $suffix eq '.exe')
+        { chmod(0755, $temporary_download_path);
+            system($temporary_download_path, "-o" . $temporary_unpack_path);
+        }
+        else
+        {
+            die "Unknown file extension '" . $suffix . "'\n";
+        }
+    }
 
-	opendir(my $dh, $temporary_unpack_path);
-	my @dirs = grep { !/^\.\.?$/ && -d catfile($temporary_unpack_path, $_) } readdir($dh);
-	closedir $dh;
-	my $unpacked_subdir = catfile($temporary_unpack_path, $dirs[0]);
+    opendir(my $dh, $temporary_unpack_path);
+    my @dirs = grep { !/^\.\.?$/ && -d catfile($temporary_unpack_path, $_) } readdir($dh);
+    closedir $dh;
+    my $unpacked_subdir = catfile($temporary_unpack_path, $dirs[0]);
 
-	if(move($unpacked_subdir, $output) == 0)
-	{
-		# move failed. Try to do a recursive copy instead
-		if(File::Copy::Recursive::dircopy($unpacked_subdir, $output) == 0)
-		{
-			print "\t\tMove/Copy Error: " . $! . "\n";
-		}
-	}
+    if (move($unpacked_subdir, $output) == 0)
+    {
+        # move failed. Try to do a recursive copy instead
+        if (File::Copy::Recursive::dircopy($unpacked_subdir, $output) == 0)
+        {
+            print "\t\tMove/Copy Error: " . $! . "\n";
+        }
+    }
 
-	# clean up
-	unlink($temporary_download_path);
-	rmtree($temporary_unpack_path);
+    # clean up
+    unlink($temporary_download_path);
+    rmtree($temporary_unpack_path);
 }
 
+sub ReadConfig
+{
+    my ($fileName) = @_;
+    my %prefs;
+    open CONFIG, "<", $fileName;
+    while (<CONFIG>) {
+        chomp;       # no newline
+        s/#.*//;     # no comments
+        s/^\s+//;    # no leading white
+        s/\s+$//;    # no trailing white
+        next unless length;    # anything left?
+        my ($var, $value) = split(/\s*=\s*/, $_, 2);
+        $prefs{$var} = $value;
+    }
+    return %prefs;
+}
 
 sub PrepareNDK
 {
-	my ($ndk) = @_;
-	my $ndk_root = $ENV{$NDK_ROOT_ENV};
-	$ndk_root = $1 if($ndk_root=~/(.*)\/$/);
+    my ($ndk) = @_;
+    my $ndk_root = $ENV{$NDK_ROOT_ENV};
+    $ndk_root = $1 if ($ndk_root =~ /(.*)\/$/);
 
-	if (-e $ndk_root and open RELEASE, "<", catfile("$ndk_root", "RELEASE.TXT"))
-	{
-		my @content = <RELEASE>;
-		close RELEASE;
-		chomp(@content);
-		my $current = $content[0];
-		print "\tCurrently installed = " . $current . "\n";
+    if (-e $ndk_root)
+    {
+        my $propFile   = catfile("$ndk_root", "source.properties");
+        my $releaseTxt = catfile("$ndk_root", "RELEASE.TXT");
 
-		# remove the possible '-rcX' or ' (64-bit)' from the end
-		my @curr_arr = split(/ |-/, $current);
-		$current = $curr_arr[0];
-		print "\tShort name = " . $current . "\n";
+        my $full_version = "Unrecognized";
 
-		if ($ndk eq $current)
-		{
-			print "\tNDK '$ndk' is already installed\n";
-			return;
-		}
-		else
-		{
-			my ($current_name,$path) = fileparse($ndk_root);
+        if (-e $releaseTxt and open RELEASE, "<", $releaseTxt)
+        {
+            my @content = <RELEASE>;
+            close RELEASE;
+            chomp(@content);
+            $full_version = $content[0];
+        }
+        elsif (-e $propFile)
+        {
+            my %prefs = ReadConfig($propFile);
+            if (exists $prefs{'Pkg.Revision'})
+            {
+                my $revision = $prefs{'Pkg.Revision'};
+                if (exists $sourcePropVersions->{$revision})
+                {
+                    $full_version = $sourcePropVersions->{$revision};
+                }
+            }
+        }
+        else
+        {
+            printf "Your current NDK is not recognized!";
+        }
 
-			$ENV{$NDK_ROOT_ENV} = catfile($path, "android-ndk-" . $ndk);
-			print "\t\$$NDK_ROOT_ENV is pointing to a mismatching NDK; using $ENV{$NDK_ROOT_ENV} instead\n";
-			PrepareNDK($ndk);
-			return;
-		}
-	}
+        print "\tCurrently installed = " . $full_version . "\n";
 
-	rmtree($ndk_root);
+        # remove the possible '-rcX' or ' (64-bit)' from the end
+        my @curr_arr = split(/ |-/, $full_version);
+        my $major_version = $curr_arr[0];
+        print "\tShort name = " . $major_version . "\n";
+        my $isSdk64bit = index($full_version, "(64-bit)") != -1;
 
-	my $archive = $ndks->{$ndk}->{$HOST_ENV};
-	die ("Unknown NDK release '$ndk' (for $HOST_ENV)") if (!$archive);
+        if ($ndk eq $major_version and $isSdk64bit)
+        {
+            print "\tNDK '$ndk' is already installed\n";
+            return;
+        }
+        else
+        {
+            if (!$isSdk64bit)
+            {
+                print "\tThe NDK version found is not 64-bit!\n";
+                print "\t64-bit NDK is required for building Android player on all supported platforms\n";
+            }
+            my ($current_name, $path) = fileparse($ndk_root);
 
-	print "\tDownloading '$ndk' to '$ndk_root'\n";
-	DownloadAndUnpackArchive($BASE_URL_NDK . $archive, $ndk_root);
+            $ENV{$NDK_ROOT_ENV} = catfile($path, "android-ndk-" . $ndk);
+            if ($ndk_root eq $ENV{$NDK_ROOT_ENV})
+            {
+                print "**Error: NDK Preparation failed!";
+                return;
+            }
+            print "\t\$$NDK_ROOT_ENV is pointing to a mismatching NDK; using $ENV{$NDK_ROOT_ENV} instead\n";
+            PrepareNDK($ndk);
+            return;
+        }
+    }
+
+    rmtree($ndk_root);
+
+    my $archive = $ndks->{$ndk}->{$HOST_ENV};
+    die("Unknown NDK release '$ndk' (for $HOST_ENV)") if (!$archive);
+
+    print "\tDownloading '$ndk' to '$ndk_root'\n";
+    if ($ndk =~ m/r13/ or $ndk =~ m/r17/)
+    {
+        DownloadAndUnpackArchive($BASE_URL_SDK . $archive, $ndk_root);
+    }
+    else
+    {
+        DownloadAndUnpackArchive($BASE_URL_NDK . $archive, $ndk_root);
+    }
 }
 
 1;

--- a/PrepareAndroidSDK.pm
+++ b/PrepareAndroidSDK.pm
@@ -169,6 +169,12 @@ our $ndks =
         "macosx"  => "android-ndk-r13b-darwin-x86_64.zip",
         "linux"   => "android-ndk-r13b-linux-x86_64.zip",
         },
+    "r16b" =>
+        {
+        "windows" => "android-ndk-r16b-windows-x86_64.zip",
+        "macosx"  => "android-ndk-r16b-darwin-x86_64.zip",
+        "linux"   => "android-ndk-r16b-linux-x86_64.zip",
+        },
     "r17" =>
         {
         "windows" => "android-ndk-r17-windows-x86_64.zip",
@@ -180,6 +186,7 @@ our $ndks =
 our $sourcePropVersions =
     {
     "13.1.3345770" => "r13b (64-bit)",
+    "16.1.4479499" => "r16b (64-bit)",
     "17.0.4754217" => "r17 (64-bit)",
     };
 
@@ -580,7 +587,7 @@ sub PrepareNDK
     die("Unknown NDK release '$ndk' (for $HOST_ENV)") if (!$archive);
 
     print "\tDownloading '$ndk' to '$ndk_root'\n";
-    if ($ndk =~ m/r13/ or $ndk =~ m/r17/)
+    if ($ndk =~ m/r13/ or $ndk =~ m/r16/ or $ndk =~ m/r17/)
     {
         DownloadAndUnpackArchive($BASE_URL_SDK . $archive, $ndk_root);
     }

--- a/PrepareAndroidSDK.pm
+++ b/PrepareAndroidSDK.pm
@@ -72,6 +72,16 @@ our $build_tools =
     "macosx"  => "build-tools_r25.0.2-macosx.zip",
     };
 
+our $gpss =
+    {
+    "froyo" =>
+        {
+        "version" => "12.0.0",
+        "url"     => "google_play_services_3265130_r12.zip",
+        "path"    => "google_play_services_froyo",
+        },
+    };
+
 our $ndks =
     {
     "r5" =>
@@ -237,11 +247,11 @@ sub GetAndroidSDK
     print "\t\$$NDK_ROOT_ENV = $ENV{$NDK_ROOT_ENV}\n" if ($ENV{$NDK_ROOT_ENV});
     print "\n";
 
-    my ($sdk, $tools, $ndk, $setenv) = @_;
+    my ($sdk, $tools, $gps, $ndk, $setenv) = @_;
 
 #   Getopt::Long::GetOptions("sdk=s"=>\$sdk, "ndk=s"=>\$ndk) or die ("Illegal cmdline options");
 
-    if ($sdk or $tools)
+    if ($sdk or $tools or $gps)
     {
         if ($sdk)
         {
@@ -250,6 +260,10 @@ sub GetAndroidSDK
         elsif ($tools)
         {
             print "Installing SDK Tools '$tools':\n";
+        }
+        elsif ($gps)
+        {
+            print "Installing Google Play Services '$gps':\n";
         }
 
         if (!$ENV{$SDK_ROOT_ENV})
@@ -270,6 +284,10 @@ sub GetAndroidSDK
         if ($sdk)
         {
             PrepareSDK($sdk);
+        }
+        if ($gps)
+        {
+            PrepareGPS($gps);
         }
         print "\n";
     }
@@ -389,6 +407,25 @@ sub PrepareSDK
     my $output = catfile($sdk_root, "platforms", $sdk);
     print "\tDownloading '$platform' to '$output'\n";
     DownloadAndUnpackArchive($BASE_URL_SDK . $platform, $output);
+}
+
+sub PrepareGPS
+{
+    my $sdk_root = $ENV{$SDK_ROOT_ENV};
+    my ($gps) = @_;
+
+    my $gps_version = $gpss->{$gps}->{'version'};
+    my $gps_url     = $gpss->{$gps}->{'url'};
+    my $gps_path    = catfile($sdk_root, 'extras', 'google', $gpss->{$gps}->{'path'});
+
+    if (-e catfile($gps_path, 'libproject', 'google-play-services_lib', 'libs', 'google-play-services.jar'))
+    {
+        print("\tGoogle Play Services '$gps_version' is already installed.\n");
+        return;
+    }
+
+    print("\tInstalling Google Play Services '$gps_version'...\n");
+    DownloadAndUnpackArchive($BASE_URL_SDK . $gps_url, $gps_path);
 }
 
 sub IsPlatformInstalled

--- a/PrepareAndroidSDK.pm
+++ b/PrepareAndroidSDK.pm
@@ -45,6 +45,7 @@ our $sdks =
     "android-19" => "android-19_r03.zip",
     "android-21" => "android-21_r02.zip",
     "android-23" => "android-23_r02.zip",
+    "android-26" => "platform-26_r02.zip",
     };
 
 our $sdk_tools =

--- a/build.pl
+++ b/build.pl
@@ -79,7 +79,7 @@ sub BuildAndroid
 	my $class_names = join(' ', @classes);
 	my $threads = 8;
 
-    PrepareAndroidSDK::GetAndroidSDK("$api", "21", "r16b", "24");
+    PrepareAndroidSDK::GetAndroidSDK("$api", "21", "froyo", "r16b", "24");
 
     system("make clean") && die("Clean failed");
     system("make api-source PLATFORM=android APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make API source");

--- a/build.pl
+++ b/build.pl
@@ -65,6 +65,9 @@ my @classes = (
 	'::java::util::Map_Entry',
 	'::java::util::NoSuchElementException',
 	'::java::util::Scanner',
+	'::javax::net::ssl::X509TrustManager',
+	'::javax::net::ssl::TrustManagerFactory',
+	'::java::security::KeyStore',
 
 	'::com::google::android::gms::ads::identifier::AdvertisingIdClient',
 	'::com::google::android::gms::common::GooglePlayServicesAvailabilityException',

--- a/build.pl
+++ b/build.pl
@@ -36,6 +36,7 @@ my @classes = (
 	'::android::os::HandlerThread',
 	'::android::os::Environment',
 	'::android::os::PowerManager',
+	'::android::os::Process',
 	'::android::os::Vibrator',
 	'::android::provider::Settings_Secure',
 	'::android::provider::Settings_System',

--- a/build.pl
+++ b/build.pl
@@ -4,7 +4,7 @@ use File::Path;
 use strict;
 use warnings;
 
-my $api = "android-23";
+my $api = "android-26";
 
 my @classes = (
 	'::android::Manifest_permission',
@@ -22,6 +22,8 @@ my @classes = (
 	'::android::hardware::input::InputManager',
 	'::android::hardware::GeomagneticField',
 	'::android::location::LocationManager',
+	'::android::media::AudioAttributes_Builder',
+	'::android::media::AudioFocusRequest_Builder',
 	'::android::media::AudioManager',
 	'::android::media::MediaCodec',
 	'::android::media::MediaCodec::BufferInfo',

--- a/build.pl
+++ b/build.pl
@@ -81,9 +81,8 @@ sub BuildAndroid
     system("make api-source PLATFORM=android APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make API source");
     system("make api-module PLATFORM=android APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make API module");
     system("make compile-static-apilib -j$threads PLATFORM=android ABI=armeabi-v7a APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android armv7 library");
+    system("make compile-static-apilib -j$threads PLATFORM=android ABI=arm64-v8a   APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android arm64 library");
     system("make compile-static-apilib -j$threads PLATFORM=android ABI=x86         APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android x86 library");
-    system("make compile-static-apilib -j$threads PLATFORM=android ABI=armeabi     APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android armv5 library");
-    system("make compile-static-apilib -j$threads PLATFORM=android ABI=mips        APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make android mips library");
 }
 
 sub ZipIt

--- a/build.pl
+++ b/build.pl
@@ -79,7 +79,7 @@ sub BuildAndroid
 	my $class_names = join(' ', @classes);
 	my $threads = 8;
 
-    PrepareAndroidSDK::GetAndroidSDK("$api", "21", "r17", "24");
+    PrepareAndroidSDK::GetAndroidSDK("$api", "21", "r16b", "24");
 
     system("make clean") && die("Clean failed");
     system("make api-source PLATFORM=android APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make API source");

--- a/build.pl
+++ b/build.pl
@@ -31,6 +31,7 @@ my @classes = (
 	'::android::media::MediaFormat',
 	'::android::media::MediaRouter',
 	'::android::net::ConnectivityManager',
+	'::android::net::wifi::WifiManager',
 	'::android::os::Build',
 	'::android::os::Build_VERSION',
 	'::android::os::HandlerThread',

--- a/build.pl
+++ b/build.pl
@@ -79,7 +79,7 @@ sub BuildAndroid
 	my $class_names = join(' ', @classes);
 	my $threads = 8;
 
-    PrepareAndroidSDK::GetAndroidSDK("$api", "21", "r10e", "24");
+    PrepareAndroidSDK::GetAndroidSDK("$api", "21", "r17", "24");
 
     system("make clean") && die("Clean failed");
     system("make api-source PLATFORM=android APINAME=\"$api\" APICLASSES=\"$class_names\"") && die("Failed to make API source");

--- a/perl_lib/File/Copy/Recursive.pm
+++ b/perl_lib/File/Copy/Recursive.pm
@@ -1,0 +1,696 @@
+package File::Copy::Recursive;
+
+use strict;
+BEGIN {
+    # Keep older versions of Perl from trying to use lexical warnings
+    $INC{'warnings.pm'} = "fake warnings entry for < 5.6 perl ($])" if $] < 5.006;
+}
+use warnings;
+
+use Carp;
+use File::Copy; 
+use File::Spec; #not really needed because File::Copy already gets it, but for good measure :)
+
+use vars qw( 
+    @ISA      @EXPORT_OK $VERSION  $MaxDepth $KeepMode $CPRFComp $CopyLink 
+    $PFSCheck $RemvBase $NoFtlPth  $ForcePth $CopyLoop $RMTrgFil $RMTrgDir 
+    $CondCopy $BdTrgWrn $SkipFlop  $DirPerms
+);
+
+require Exporter;
+@ISA = qw(Exporter);
+@EXPORT_OK = qw(fcopy rcopy dircopy fmove rmove dirmove pathmk pathrm pathempty pathrmdir);
+$VERSION = '0.38';
+
+$MaxDepth = 0;
+$KeepMode = 1;
+$CPRFComp = 0; 
+$CopyLink = eval { local $SIG{'__DIE__'};symlink '',''; 1 } || 0;
+$PFSCheck = 1;
+$RemvBase = 0;
+$NoFtlPth = 0;
+$ForcePth = 0;
+$CopyLoop = 0;
+$RMTrgFil = 0;
+$RMTrgDir = 0;
+$CondCopy = {};
+$BdTrgWrn = 0;
+$SkipFlop = 0;
+$DirPerms = 0777; 
+
+my $samecheck = sub {
+   return 1 if $^O eq 'MSWin32'; # need better way to check for this on winders...
+   return if @_ != 2 || !defined $_[0] || !defined $_[1];
+   return if $_[0] eq $_[1];
+
+   my $one = '';
+   if($PFSCheck) {
+      $one    = join( '-', ( stat $_[0] )[0,1] ) || '';
+      my $two = join( '-', ( stat $_[1] )[0,1] ) || '';
+      if ( $one eq $two && $one ) {
+          carp "$_[0] and $_[1] are identical";
+          return;
+      }
+   }
+
+   if(-d $_[0] && !$CopyLoop) {
+      $one    = join( '-', ( stat $_[0] )[0,1] ) if !$one;
+      my $abs = File::Spec->rel2abs($_[1]);
+      my @pth = File::Spec->splitdir( $abs );
+      while(@pth) {
+         my $cur = File::Spec->catdir(@pth);
+         last if !$cur; # probably not necessary, but nice to have just in case :)
+         my $two = join( '-', ( stat $cur )[0,1] ) || '';
+         if ( $one eq $two && $one ) {
+             # $! = 62; # Too many levels of symbolic links
+             carp "Caught Deep Recursion Condition: $_[0] contains $_[1]";
+             return;
+         }
+      
+         pop @pth;
+      }
+   }
+
+   return 1;
+};
+
+my $glob = sub {
+    my ($do, $src_glob, @args) = @_;
+    
+    local $CPRFComp = 1;
+    
+    my @rt;
+    for my $path ( glob($src_glob) ) {
+        my @call = [$do->($path, @args)] or return;
+        push @rt, \@call;
+    }
+    
+    return @rt;
+};
+
+my $move = sub {
+   my $fl = shift;
+   my @x;
+   if($fl) {
+      @x = fcopy(@_) or return;
+   } else {
+      @x = dircopy(@_) or return;
+   }
+   if(@x) {
+      if($fl) {
+         unlink $_[0] or return;
+      } else {
+         pathrmdir($_[0]) or return;
+      }
+      if($RemvBase) {
+         my ($volm, $path) = File::Spec->splitpath($_[0]);
+         pathrm(File::Spec->catpath($volm,$path,''), $ForcePth, $NoFtlPth) or return;
+      }
+   }
+  return wantarray ? @x : $x[0];
+};
+
+my $ok_todo_asper_condcopy = sub {
+    my $org = shift;
+    my $copy = 1;
+    if(exists $CondCopy->{$org}) {
+        if($CondCopy->{$org}{'md5'}) {
+
+        }
+        if($copy) {
+
+        }
+    }
+    return $copy;
+};
+
+sub fcopy { 
+   $samecheck->(@_) or return;
+   if($RMTrgFil && (-d $_[1] || -e $_[1]) ) {
+      my $trg = $_[1];
+      if( -d $trg ) {
+        my @trgx = File::Spec->splitpath( $_[0] );
+        $trg = File::Spec->catfile( $_[1], $trgx[ $#trgx ] );
+      }
+      $samecheck->($_[0], $trg) or return;
+      if(-e $trg) {
+         if($RMTrgFil == 1) {
+            unlink $trg or carp "\$RMTrgFil failed: $!";
+         } else {
+            unlink $trg or return;
+         }
+      }
+   }
+   my ($volm, $path) = File::Spec->splitpath($_[1]);
+   if($path && !-d $path) {
+      pathmk(File::Spec->catpath($volm,$path,''), $NoFtlPth);
+   }
+   if( -l $_[0] && $CopyLink ) {
+      carp "Copying a symlink ($_[0]) whose target does not exist" 
+          if !-e readlink($_[0]) && $BdTrgWrn;
+      symlink readlink(shift()), shift() or return;
+   } else {  
+      copy(@_) or return;
+
+      my @base_file = File::Spec->splitpath($_[0]);
+      my $mode_trg = -d $_[1] ? File::Spec->catfile($_[1], $base_file[ $#base_file ]) : $_[1];
+
+      chmod scalar((stat($_[0]))[2]), $mode_trg if $KeepMode;
+   }
+   return wantarray ? (1,0,0) : 1; # use 0's incase they do math on them and in case rcopy() is called in list context = no uninit val warnings
+}
+
+sub rcopy { 
+    if (-l $_[0] && $CopyLink) {
+        goto &fcopy;    
+    }
+    
+    goto &dircopy if -d $_[0] || substr( $_[0], ( 1 * -1), 1) eq '*';
+    goto &fcopy;
+}
+
+sub rcopy_glob {
+    $glob->(\&rcopy, @_);
+}
+
+sub dircopy {
+   if($RMTrgDir && -d $_[1]) {
+      if($RMTrgDir == 1) {
+         pathrmdir($_[1]) or carp "\$RMTrgDir failed: $!";
+      } else {
+         pathrmdir($_[1]) or return;
+      }
+   }
+   my $globstar = 0;
+   my $_zero = $_[0];
+   my $_one = $_[1];
+   if ( substr( $_zero, ( 1 * -1 ), 1 ) eq '*') {
+       $globstar = 1;
+       $_zero = substr( $_zero, 0, ( length( $_zero ) - 1 ) );
+   }
+
+   $samecheck->(  $_zero, $_[1] ) or return;
+   if ( !-d $_zero || ( -e $_[1] && !-d $_[1] ) ) {
+       $! = 20; 
+       return;
+   } 
+
+   if(!-d $_[1]) {
+      pathmk($_[1], $NoFtlPth) or return;
+   } else {
+      if($CPRFComp && !$globstar) {
+         my @parts = File::Spec->splitdir($_zero);
+         while($parts[ $#parts ] eq '') { pop @parts; }
+         $_one = File::Spec->catdir($_[1], $parts[$#parts]);
+      }
+   }
+   my $baseend = $_one;
+   my $level   = 0;
+   my $filen   = 0;
+   my $dirn    = 0;
+
+   my $recurs; #must be my()ed before sub {} since it calls itself
+   $recurs =  sub {
+      my ($str,$end,$buf) = @_;
+      $filen++ if $end eq $baseend; 
+      $dirn++ if $end eq $baseend;
+      
+      $DirPerms = oct($DirPerms) if substr($DirPerms,0,1) eq '0';
+      mkdir($end,$DirPerms) or return if !-d $end;
+      chmod scalar((stat($str))[2]), $end if $KeepMode;
+      if($MaxDepth && $MaxDepth =~ m/^\d+$/ && $level >= $MaxDepth) {
+         return ($filen,$dirn,$level) if wantarray;
+         return $filen;
+      }
+      $level++;
+
+      
+      my @files;
+      if ( $] < 5.006 ) {
+          opendir(STR_DH, $str) or return;
+          @files = grep( $_ ne '.' && $_ ne '..', readdir(STR_DH));
+          closedir STR_DH;
+      }
+      else {
+          opendir(my $str_dh, $str) or return;
+          @files = grep( $_ ne '.' && $_ ne '..', readdir($str_dh));
+          closedir $str_dh;
+      }
+
+      for my $file (@files) {
+          my ($file_ut) = $file =~ m{ (.*) }xms;
+          my $org = File::Spec->catfile($str, $file_ut);
+          my $new = File::Spec->catfile($end, $file_ut);
+          if( -l $org && $CopyLink ) {
+              carp "Copying a symlink ($org) whose target does not exist" 
+                  if !-e readlink($org) && $BdTrgWrn;
+              symlink readlink($org), $new or return;
+          } 
+          elsif(-d $org) {
+              $recurs->($org,$new,$buf) if defined $buf;
+              $recurs->($org,$new) if !defined $buf;
+              $filen++;
+              $dirn++;
+          } 
+          else {
+              if($ok_todo_asper_condcopy->($org)) {
+                  if($SkipFlop) {
+                      fcopy($org,$new,$buf) or next if defined $buf;
+                      fcopy($org,$new) or next if !defined $buf;                      
+                  }
+                  else {
+                      fcopy($org,$new,$buf) or return if defined $buf;
+                      fcopy($org,$new) or return if !defined $buf;
+                  }
+                  chmod scalar((stat($org))[2]), $new if $KeepMode;
+                  $filen++;
+              }
+          }
+      }
+      1;
+   };
+
+   $recurs->($_zero, $_one, $_[2]) or return;
+   return wantarray ? ($filen,$dirn,$level) : $filen;
+}
+
+sub fmove { $move->(1, @_) } 
+
+sub rmove { 
+    if (-l $_[0] && $CopyLink) {
+        goto &fmove;    
+    }
+    
+    goto &dirmove if -d $_[0] || substr( $_[0], ( 1 * -1), 1) eq '*';
+    goto &fmove;
+}
+
+sub rmove_glob {
+    $glob->(\&rmove, @_);
+}
+
+sub dirmove { $move->(0, @_) }
+
+sub pathmk {
+   my @parts = File::Spec->splitdir( shift() );
+   my $nofatal = shift;
+   my $pth = $parts[0];
+   my $zer = 0;
+   if(!$pth) {
+      $pth = File::Spec->catdir($parts[0],$parts[1]);
+      $zer = 1;
+   }
+   for($zer..$#parts) {
+      $DirPerms = oct($DirPerms) if substr($DirPerms,0,1) eq '0';
+      mkdir($pth,$DirPerms) or return if !-d $pth && !$nofatal;
+      mkdir($pth,$DirPerms) if !-d $pth && $nofatal;
+      $pth = File::Spec->catdir($pth, $parts[$_ + 1]) unless $_ == $#parts;
+   }
+   1;
+} 
+
+sub pathempty {
+   my $pth = shift; 
+
+   return 2 if !-d $pth;
+
+   my @names;
+   my $pth_dh;
+   if ( $] < 5.006 ) {
+       opendir(PTH_DH, $pth) or return;
+       @names = grep !/^\.+$/, readdir(PTH_DH);
+   }
+   else {
+       opendir($pth_dh, $pth) or return;
+       @names = grep !/^\.+$/, readdir($pth_dh);       
+   }
+   
+   for my $name (@names) {
+      my ($name_ut) = $name =~ m{ (.*) }xms;
+      my $flpth     = File::Spec->catdir($pth, $name_ut);
+
+      if( -l $flpth ) {
+	      unlink $flpth or return; 
+      }
+      elsif(-d $flpth) {
+          pathrmdir($flpth) or return;
+      } 
+      else {
+          unlink $flpth or return;
+      }
+   }
+
+   if ( $] < 5.006 ) {
+       closedir PTH_DH;
+   }
+   else {
+       closedir $pth_dh;
+   }
+   
+   1;
+}
+
+sub pathrm {
+   my $path = shift;
+   return 2 if !-d $path;
+   my @pth = File::Spec->splitdir( $path );
+   my $force = shift;
+
+   while(@pth) { 
+      my $cur = File::Spec->catdir(@pth);
+      last if !$cur; # necessary ??? 
+      if(!shift()) {
+         pathempty($cur) or return if $force;
+         rmdir $cur or return;
+      } 
+      else {
+         pathempty($cur) if $force;
+         rmdir $cur;
+      }
+      pop @pth;
+   }
+   1;
+}
+
+sub pathrmdir {
+    my $dir = shift;
+    if( -e $dir ) {
+        return if !-d $dir;
+    }
+    else {
+        return 2;
+    }
+
+    pathempty($dir) or return;
+    
+    rmdir $dir or return;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+File::Copy::Recursive - Perl extension for recursively copying files and directories
+
+=head1 SYNOPSIS
+
+  use File::Copy::Recursive qw(fcopy rcopy dircopy fmove rmove dirmove);
+
+  fcopy($orig,$new[,$buf]) or die $!;
+  rcopy($orig,$new[,$buf]) or die $!;
+  dircopy($orig,$new[,$buf]) or die $!;
+
+  fmove($orig,$new[,$buf]) or die $!;
+  rmove($orig,$new[,$buf]) or die $!;
+  dirmove($orig,$new[,$buf]) or die $!;
+  
+  rcopy_glob("orig/stuff-*", $trg [, $buf]) or die $!;
+  rmove_glob("orig/stuff-*", $trg [,$buf]) or die $!;
+
+=head1 DESCRIPTION
+
+This module copies and moves directories recursively (or single files, well... singley) to an optional depth and attempts to preserve each file or directory's mode.
+
+=head1 EXPORT
+
+None by default. But you can export all the functions as in the example above and the path* functions if you wish.
+
+=head2 fcopy()
+
+This function uses File::Copy's copy() function to copy a file but not a directory. Any directories are recursively created if need be.
+One difference to File::Copy::copy() is that fcopy attempts to preserve the mode (see Preserving Mode below)
+The optional $buf in the synopsis if the same as File::Copy::copy()'s 3rd argument
+returns the same as File::Copy::copy() in scalar context and 1,0,0 in list context to accomidate rcopy()'s list context on regular files. (See below for more info)
+
+=head2 dircopy()
+
+This function recursively traverses the $orig directory's structure and recursively copies it to the $new directory.
+$new is created if necessary (multiple non existant directories is ok (IE foo/bar/baz). The script logically and portably creates all of them if necessary).
+It attempts to preserve the mode (see Preserving Mode below) and 
+by default it copies all the way down into the directory, (see Managing Depth) below.
+If a directory is not specified it croaks just like fcopy croaks if its not a file that is specified.
+
+returns true or false, for true in scalar context it returns the number of files and directories copied,
+In list context it returns the number of files and directories, number of directories only, depth level traversed.
+
+  my $num_of_files_and_dirs = dircopy($orig,$new);
+  my($num_of_files_and_dirs,$num_of_dirs,$depth_traversed) = dircopy($orig,$new);
+  
+Normally it stops and return's if a copy fails, to continue on regardless set $File::Copy::Recursive::SkipFlop to true.
+
+    local $File::Copy::Recursive::SkipFlop = 1;
+
+That way it will copy everythgingit can ina directory and won't stop because of permissions, etc...
+
+=head2 rcopy()
+
+This function will allow you to specify a file *or* directory. It calls fcopy() if its a file and dircopy() if its a directory.
+If you call rcopy() (or fcopy() for that matter) on a file in list context, the values will be 1,0,0 since no directories and no depth are used. 
+This is important becasue if its a directory in list context and there is only the initial directory the return value is 1,1,1.
+
+=head2 rcopy_glob()
+
+This function lets you specify a pattern suitable for perl's glob() as the first argument. Subsequently each path returned by perl's glob() gets rcopy()ied.
+
+It returns and array whose items are array refs that contain the return value of each rcopy() call.
+
+It forces behavior as if $File::Copy::Recursive::CPRFComp is true.
+
+=head2 fmove()
+
+Copies the file then removes the original. You can manage the path the original file is in according to $RemvBase.
+
+=head2 dirmove()
+
+Uses dircopy() to copy the directory then removes the original. You can manage the path the original directory is in according to $RemvBase.
+
+=head2 rmove()
+
+Like rcopy() but calls fmove() or dirmove() instead.
+
+=head2 rmove_glob()
+
+Like rcopy_glob() but calls rmove() instead of rcopy()
+
+=head3 $RemvBase
+
+Default is false. When set to true the *move() functions will not only attempt to remove the original file or directory but will remove the given path it is in.
+
+So if you:
+
+   rmove('foo/bar/baz', '/etc/');
+   # "baz" is removed from foo/bar after it is successfully copied to /etc/
+   
+   local $File::Copy::Recursive::Remvbase = 1;
+   rmove('foo/bar/baz','/etc/');
+   # if baz is successfully copied to /etc/ :
+   # first "baz" is removed from foo/bar
+   # then "foo/bar is removed via pathrm()
+
+=head4 $ForcePth
+
+Default is false. When set to true it calls pathempty() before any directories are removed to empty the directory so it can be rmdir()'ed when $RemvBase is in effect.
+
+=head2 Creating and Removing Paths
+
+=head3 $NoFtlPth
+
+Default is false. If set to true  rmdir(), mkdir(), and pathempty() calls in pathrm() and pathmk() do not return() on failure.
+
+If its set to true they just silently go about their business regardless. This isn't a good idea but its there if you want it.
+
+=head3 $DirPerms
+
+Mode to pass to any mkdir() calls. Defaults to 0777 as per umask()'s POD. Explicitly having this allows older perls to be able to use FCR and might add a bit of flexibility for you.
+
+Any value you set it to should be suitable for oct()
+
+=head3 Path functions
+
+These functions exist soley because they were necessary for the move and copy functions to have the features they do and not because they are of themselves the purpose of this module. That being said, here is how they work so you can understand how the copy and move funtions work and use them by themselves if you wish.
+
+=head4 pathrm()
+
+Removes a given path recursively. It removes the *entire* path so be carefull!!!
+
+Returns 2 if the given path is not a directory.
+
+  File::Copy::Recursive::pathrm('foo/bar/baz') or die $!;
+  # foo no longer exists
+
+Same as:
+
+  rmdir 'foo/bar/baz' or die $!;
+  rmdir 'foo/bar' or die $!;
+  rmdir 'foo' or die $!;
+
+An optional second argument makes it call pathempty() before any rmdir()'s when set to true.
+
+  File::Copy::Recursive::pathrm('foo/bar/baz', 1) or die $!;
+  # foo no longer exists
+
+Same as:PFSCheck
+
+  File::Copy::Recursive::pathempty('foo/bar/baz') or die $!;
+  rmdir 'foo/bar/baz' or die $!;
+  File::Copy::Recursive::pathempty('foo/bar/') or die $!;
+  rmdir 'foo/bar' or die $!;
+  File::Copy::Recursive::pathempty('foo/') or die $!;
+  rmdir 'foo' or die $!;
+
+An optional third argument acts like $File::Copy::Recursive::NoFtlPth, again probably not a good idea.
+
+=head4 pathempty()
+
+Recursively removes the given directory's contents so it is empty. returns 2 if argument is not a directory, 1 on successfully emptying the directory.
+
+   File::Copy::Recursive::pathempty($pth) or die $!;
+   # $pth is now an empty directory
+
+=head4 pathmk()
+
+Creates a given path recursively. Creates foo/bar/baz even if foo does not exist.
+
+   File::Copy::Recursive::pathmk('foo/bar/baz') or die $!;
+
+An optional second argument if true acts just like $File::Copy::Recursive::NoFtlPth, which means you'd never get your die() if something went wrong. Again, probably a *bad* idea.
+
+=head4 pathrmdir()
+
+Same as rmdir() but it calls pathempty() first to recursively empty it first since rmdir can not remove a directory with contents.
+Just removes the top directory the path given instead of the entire path like pathrm(). Return 2 if given argument does not exist (IE its already gone). Return false if it exists but is not a directory.
+
+=head2 Preserving Mode
+
+By default a quiet attempt is made to change the new file or directory to the mode of the old one.
+To turn this behavior off set
+  $File::Copy::Recursive::KeepMode
+to false;
+
+=head2 Managing Depth
+
+You can set the maximum depth a directory structure is recursed by setting:
+  $File::Copy::Recursive::MaxDepth 
+to a whole number greater than 0.
+
+=head2 SymLinks
+
+If your system supports symlinks then symlinks will be copied as symlinks instead of as the target file.
+Perl's symlink() is used instead of File::Copy's copy()
+You can customize this behavior by setting $File::Copy::Recursive::CopyLink to a true or false value.
+It is already set to true or false dending on your system's support of symlinks so you can check it with an if statement to see how it will behave:
+
+    if($File::Copy::Recursive::CopyLink) {
+        print "Symlinks will be preserved\n";
+    } else {
+        print "Symlinks will not be preserved because your system does not support it\n";
+    }
+
+If symlinks are being copied you can set $File::Copy::Recursive::BdTrgWrn to true to make it carp when it copies a link whose target does not exist. Its false by default.
+
+    local $File::Copy::Recursive::BdTrgWrn  = 1;
+
+=head2 Removing existing target file or directory before copying.
+
+This can be done by setting $File::Copy::Recursive::RMTrgFil or $File::Copy::Recursive::RMTrgDir for file or directory behavior respectively.
+
+0 = off (This is the default)
+
+1 = carp() $! if removal fails
+
+2 = return if removal fails
+
+    local $File::Copy::Recursive::RMTrgFil = 1;
+    fcopy($orig, $target) or die $!;
+    # if it fails it does warn() and keeps going
+
+    local $File::Copy::Recursive::RMTrgDir = 2;
+    dircopy($orig, $target) or die $!;
+    # if it fails it does your "or die"
+
+This should be unnecessary most of the time but its there if you need it :)
+
+=head2 Turning off stat() check
+
+By default the files or directories are checked to see if they are the same (IE linked, or two paths (absolute/relative or different relative paths) to the same file) by comparing the file's stat() info. 
+It's a very efficient check that croaks if they are and shouldn't be turned off but if you must for some weird reason just set $File::Copy::Recursive::PFSCheck to a false value. ("PFS" stands for "Physical File System")
+
+=head2 Emulating cp -rf dir1/ dir2/
+
+By default dircopy($dir1,$dir2) will put $dir1's contents right into $dir2 whether $dir2 exists or not.
+
+You can make dircopy() emulate cp -rf by setting $File::Copy::Recursive::CPRFComp to true.
+
+NOTE: This only emulates -f in the sense that it does not prompt. It does not remove the target file or directory if it exists.
+If you need to do that then use the variables $RMTrgFil and $RMTrgDir described in "Removing existing target file or directory before copying" above.
+
+That means that if $dir2 exists it puts the contents into $dir2/$dir1 instead of $dir2 just like cp -rf.
+If $dir2 does not exist then the contents go into $dir2 like normal (also like cp -rf)
+
+So assuming 'foo/file':
+
+    dircopy('foo', 'bar') or die $!;
+    # if bar does not exist the result is bar/file
+    # if bar does exist the result is bar/file
+
+    $File::Copy::Recursive::CPRFComp = 1;
+    dircopy('foo', 'bar') or die $!;
+    # if bar does not exist the result is bar/file
+    # if bar does exist the result is bar/foo/file
+
+You can also specify a star for cp -rf glob type behavior:
+
+    dircopy('foo/*', 'bar') or die $!;
+    # if bar does not exist the result is bar/file
+    # if bar does exist the result is bar/file
+
+    $File::Copy::Recursive::CPRFComp = 1;
+    dircopy('foo/*', 'bar') or die $!;
+    # if bar does not exist the result is bar/file
+    # if bar does exist the result is bar/file
+
+NOTE: The '*' is only like cp -rf foo/* and *DOES NOT EXPAND PARTIAL DIRECTORY NAMES LIKE YOUR SHELL DOES* (IE not like cp -rf fo* to copy foo/*)
+
+=head2 Allowing Copy Loops
+
+If you want to allow:
+
+  cp -rf . foo/
+
+type behavior set $File::Copy::Recursive::CopyLoop to true.
+
+This is false by default so that a check is done to see if the source directory will contain the target directory and croaks to avoid this problem.
+
+If you ever find a situation where $CopyLoop = 1 is desirable let me know (IE its a bad bad idea but is there if you want it)
+
+(Note: On Windows this was necessary since it uses stat() to detemine samedness and stat() is essencially useless for this on Windows. 
+The test is now simply skipped on Windows but I'd rather have an actual reliable check if anyone in Microsoft land would care to share)
+
+=head1 SEE ALSO
+
+L<File::Copy> L<File::Spec>
+
+=head1 TO DO
+
+I am currently working on and reviewing some other modules to use in the new interface so we can lose the horrid globals as well as some other undesirable traits and also more easily make available some long standing requests.
+
+Tests will be easier to do with the new interface and hence the testing focus will shift to the new interface and aim to be comprehensive.
+
+The old interface will work, it just won't be brought in until it is used, so it will add no overhead for users of the new interface.
+
+I'll add this after the latest verision has been out for a while with no new features or issues found :)
+
+=head1 AUTHOR
+
+Daniel Muey, L<http://drmuey.com/cpan_contact.pl>
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright 2004 by Daniel Muey
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself. 
+
+=cut

--- a/templates/android.os.Bundle.cpp
+++ b/templates/android.os.Bundle.cpp
@@ -6,11 +6,6 @@ void Bundle::__Initialize() { }
 // --------------------------------------------------------
 // Copied from android::os::BaseBundle
 // --------------------------------------------------------
-::jvoid Bundle::Remove(const ::java::lang::String& arg0) const
-{
-	static jmethodID methodID = jni::GetMethodID(__CLASS, "remove", "(Ljava/lang/String;)V");
-	return ::jvoid(jni::Op<jvoid>::CallMethod(m_Object, methodID, (jobject)arg0));
-}
 ::java::lang::Object Bundle::Get(const ::java::lang::String& arg0) const
 {
 	static jmethodID methodID = jni::GetMethodID(__CLASS, "get", "(Ljava/lang/String;)Ljava/lang/Object;");

--- a/templates/android.os.Bundle.h
+++ b/templates/android.os.Bundle.h
@@ -4,7 +4,6 @@
 // --------------------------------------------------------
 // Copied from android::os::BaseBundle
 // --------------------------------------------------------
-::jvoid Remove(const ::java::lang::String& arg0) const;
 ::java::lang::Object Get(const ::java::lang::String& arg0) const;
 ::jboolean GetBoolean(const ::java::lang::String& arg0) const;
 ::jboolean GetBoolean(const ::java::lang::String& arg0, const ::jboolean& arg1) const;


### PR DESCRIPTION
Previous changes to LocalFrame were wrong since LocalFrame was always pushed when the error was being detected. There were no "hidden" errors that were missed by pushing LocalFrame.
According to android documentation https://developer.android.com/training/articles/perf-jni#exceptions PushLocalFrame can be called with a pending exception, so there is no need to do any exception clearing in the LocalFrame either.
There was another logical problem that we considered a LocalFrame pushed only when there was no errors, however since LocalFrame was also pushed when the exception was detected, some of the successfully pushed local frames were never popped and that was causing a crash on some older devices. By making sure that all pushed local frames are popped later on the crash on Android 4.x devices was gone.